### PR TITLE
Fix status variable typo

### DIFF
--- a/check_auditd
+++ b/check_auditd
@@ -227,7 +227,7 @@ while read -r key value; do
 
     # TODO: move this out of the loop
     if [[ $key == 'rules' && $value -le 0 ]]; then
-        STATUS="$WARNING no configured audit rules "
+        STATUS="$WARN no configured audit rules "
         CODE=1
         sign='!'
     elif [[ $key == 'pid' && $value -le 0 ]]; then


### PR DESCRIPTION
## Summary
- fix typo in audit rules check

## Testing
- `shellcheck check_auditd`
- `./check_auditd -h`

------
https://chatgpt.com/codex/tasks/task_e_684073204438832e80188befa9b60384