### PR TITLE
Add help verification step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,10 @@ jobs:
           chmod +x ./check_auditd
           bash -n ./check_auditd
 
+      - name: Verify check_auditd help
+        run: |
+          ./check_auditd --help
+
       # - name: TODO: run the script, figure out how to make this work
         # run: |
           # systemctl start auditd


### PR DESCRIPTION
## Summary
- in the GitHub workflow, after running bash syntax checks, add a step
  that runs `./check_auditd --help`

## Testing
- `shellcheck ./check_auditd`
- `bash -n ./check_auditd`
- `./check_auditd --help`

------
https://chatgpt.com/codex/tasks/task_e_684099aa9080832e899ea65673cc1c54